### PR TITLE
Support moving out of record.

### DIFF
--- a/include/trecpp/trecpp.hpp
+++ b/include/trecpp/trecpp.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <istream>
 #include <ostream>
 #include <string>
@@ -26,10 +27,12 @@ class Record {
         : docno_(std::move(docno)), url_(std::move(url)), content_(std::move(content))
     {}
     [[nodiscard]] auto content_length() const -> std::size_t { return content_.size(); }
-    [[nodiscard]] auto content() -> std::string & { return content_; }
+    [[nodiscard]] auto content() -> std::string && { return std::move(content_); }
     [[nodiscard]] auto content() const -> std::string const & { return content_; }
     [[nodiscard]] auto url() const -> std::string const & { return url_; }
+    [[nodiscard]] auto url() -> std::string && { return std::move(url_); }
     [[nodiscard]] auto trecid() const -> std::string const & { return docno_; }
+    [[nodiscard]] auto trecid() -> std::string && { return std::move(docno_); }
 
     friend std::ostream &operator<<(std::ostream &os, Record const &record);
 };
@@ -208,8 +211,8 @@ namespace detail {
 
 } // namespace detail
 
-template <typename Record_Handler, typename Error_Handler>
-auto match(Result const &result, Record_Handler &&record_handler, Error_Handler &&error_handler)
+template <typename R, typename Record_Handler, typename Error_Handler>
+auto match(R &&result, Record_Handler &&record_handler, Error_Handler &&error_handler)
 {
     if (auto *record = std::get_if<Record>(&result); record != nullptr) {
         if constexpr (std::is_same_v<decltype(record_handler(*record)), void>) {

--- a/test/test_trecpp.cpp
+++ b/test/test_trecpp.cpp
@@ -346,3 +346,29 @@ TEST_CASE("Read text record", "[unit]")
     REQUIRE(record->url() == "");
     REQUIRE(record->content() == "");
 }
+
+TEST_CASE("Match result", "[unit]")
+{
+    Result result(Record("01", "URL", "CONTENT"));
+    std::string trecid;
+    // Works when mutable
+    match(
+        result,
+        [&trecid](auto&& record){
+            trecid = std::move(record.trecid()); // move out of record
+            REQUIRE(record.url() == "URL");
+            REQUIRE(record.content() == "CONTENT");
+        },
+        [](auto&& error){}
+    );
+    // Works when const
+    match(
+        result,
+        [](auto const& record){
+            REQUIRE(record.trecid() != "01"); // moved out so not equal
+            REQUIRE(record.url() == "URL");
+            REQUIRE(record.content() == "CONTENT");
+        },
+        [](auto&& error){}
+    );
+}


### PR DESCRIPTION
Currently in PISA, we use `std::move` to get the data from the records to avoid copying strings, but it has no effect because `match` and accessors only support `const`. This PR fixes that by introducing a `&&` version of each accessor, and switching `const&` to a forwarding reference in `match`.